### PR TITLE
Fix submenu link typo

### DIFF
--- a/content/submenu_examencommissie.md
+++ b/content/submenu_examencommissie.md
@@ -1,5 +1,5 @@
 +++
-title = "Submenu Examencommisie"
+title = "Submenu Examencommissie"
 url = ""
 layout = ""
 build  = { list = false, render = false }

--- a/layouts/shortcodes/submenus.html
+++ b/layouts/shortcodes/submenus.html
@@ -23,7 +23,7 @@
 </div>
 
 <div id="content-3" class="submenu-content">
-  {{ with site.GetPage "submenu_examencommisie" }}
+  {{ with site.GetPage "submenu_examencommissie" }}
     {{ .Content }}
   {{ end }}
 </div>


### PR DESCRIPTION
## Summary
- rename `submenu_examencommisie` page to `submenu_examencommissie`
- fix the title spelling
- update shortcode to look for the new page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68580339b45483239c75ef34c4d1b3a6